### PR TITLE
Amend Empty Contact Card Display

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -97,9 +97,6 @@
     -fx-label-padding: 0 0 0 0;
     -fx-graphic-text-gap: 0;
     -fx-background-radius: 30px;
-    -fx-border-color: black;
-    -fx-border-radius: 30px;
-    -fx-border-width: 2px;
     -fx-padding: 6px;
     -fx-border-insets: 6px;
     -fx-background-insets: 6px;
@@ -107,6 +104,9 @@
 
 .list-cell:filled {
     -fx-background-color: #f0f0e6;
+    -fx-border-color: black;
+    -fx-border-radius: 30px;
+    -fx-border-width: 2px;
 }
 
 .list-cell:filled:selected {


### PR DESCRIPTION
This PR will amend CSS to remove contact card display of empty contacts from find commands for a cleaner look.

Resolves #74.