### PR TITLE
Add commands to reset tutorials to not taken place 

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -24,6 +24,12 @@ public class Messages {
             "Person: %1$s is already marked as present for Tutorial: %2$s";
     public static final String MESSAGE_UNMARK_UNNECESSARY = "Person: %2$s is already marked absent from Tutorial %1$s";
     public static final String MESSAGE_UNMARK_SUCCESS = "Marked absent from Tutorial %2$s for Person: %1$s";
+
+    public static final String MESSAGE_RESET_UNNECESSARY =
+            "Tutorial: %2$s is already marked as not taken place for Person: %1$s";
+
+    public static final String MESSAGE_RESET_SUCCESS = "Marked not taken place in Tutorial: %2$s for Person: %1$s";
+
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/seedu/address/logic/commands/ResetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResetCommand.java
@@ -1,0 +1,100 @@
+package seedu.address.logic.commands;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.AttendanceStatus;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Tutorial;
+
+public class ResetCommand extends Command {
+
+    public static final String COMMAND_WORD = "reset";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Resets attendance for the contact "
+            + "by the index number used in the last person listing and for the tutorial number inputted. "
+            + "Parameters: INDEX (must be a positive integer) "
+            + "tut/TUTORIAL\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + "tut/1";
+
+    public static final String MESSAGE_RESET_UNNECESSARY =
+            "Tutorial: %2$s is already marked as not taken place for Person: %1$s";
+
+    public static final String MESSAGE_RESET_SUCCESS = "Marked not taken place in Tutorial: %2$s for Person: %1$s";
+
+    private final Index index;
+    private final Tutorial tutorial;
+
+    /**
+     * @param index The index of the person to be marked.
+     * @param tutorial Tutorial to set as not taken place.
+     */
+    public ResetCommand(Index index, Tutorial tutorial) {
+        this.index = index;
+        this.tutorial = tutorial;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Person> currDisplayedList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= currDisplayedList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = currDisplayedList.get(index.getZeroBased());
+        Map<Tutorial, AttendanceStatus> newTutorials = new LinkedHashMap<>(personToEdit.getTutorials());
+        if (newTutorials.get(tutorial) == AttendanceStatus.NOT_TAKEN_PLACE) {
+            throw new CommandException(
+                    String.format(MESSAGE_RESET_UNNECESSARY, Messages.format(personToEdit), tutorial.tutorial));
+        }
+
+        newTutorials.put(tutorial, AttendanceStatus.PRESENT);
+
+        Person editedPerson = new Person(
+                personToEdit.getName(),
+                personToEdit.getStudentId(),
+                personToEdit.getPhone(),
+                personToEdit.getEmail(),
+                personToEdit.getTags(),
+                newTutorials
+        );
+        model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(generateSuccessMessage(editedPerson));
+    }
+
+    /**
+     * Generates a command execution success message based on whether
+     * the tutorial was marked as not taken place.
+     * {@code personToEdit}.
+     */
+    private String generateSuccessMessage(Person personToEdit) {
+        return String.format(MESSAGE_RESET_SUCCESS, Messages.format(personToEdit), tutorial.tutorial);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ResetCommand)) {
+            return false;
+        }
+
+        // state check
+        ResetCommand e = (ResetCommand) other;
+        return index.equals(e.index)
+                && tutorial.equals(e.tutorial);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ResetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResetCommand.java
@@ -40,6 +40,7 @@ public class ResetCommand extends Command {
     }
 
     /**
+     * Takes a person and tutorial and resets the specified tutorial and returns that person with the new tutorials.
      * @param personToEdit The person whose attendance will be reset.
      * @param tutorial The tutorial to reset attendance for.
      */
@@ -77,8 +78,7 @@ public class ResetCommand extends Command {
     }
 
     /**
-     * Generates a command execution success message based on whether
-     * the tutorial was marked as not taken place.
+     * Generates a command execution success message for the tutorials that were marked as not taken place.
      * {@code personToEdit}.
      */
     private String generateSuccessMessage(List<Person> personListToEdit) {

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.commands.ResetCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.UnmarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -85,6 +86,9 @@ public class AddressBookParser {
 
         case UnmarkCommand.COMMAND_WORD:
             return new UnmarkCommandParser().parse(arguments);
+
+        case ResetCommand.COMMAND_WORD:
+            return new ResetCommandParser().parse(arguments);
 
         case SortCommand.COMMAND_WORD:
             return new SortCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/ResetCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResetCommandParser.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.MarkCommand;
 import seedu.address.logic.commands.ResetCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Tutorial;
@@ -22,7 +21,7 @@ public class ResetCommandParser implements Parser<ResetCommand> {
                 PREFIX_TUTORIAL);
 
         if (!argMultimap.arePrefixesPresent(PREFIX_TUTORIAL)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ResetCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TUTORIAL);

--- a/src/main/java/seedu/address/logic/parser/ResetCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResetCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.commands.ResetCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Tutorial;
+
+/**
+ * Parses input arguments and creates a new ResetCommand object.
+ */
+public class ResetCommandParser implements Parser<ResetCommand> {
+
+    @Override
+    public ResetCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+                PREFIX_TUTORIAL);
+
+        if (!argMultimap.arePrefixesPresent(PREFIX_TUTORIAL)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TUTORIAL);
+        Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        Tutorial tutorial = ParserUtil.parseTutorial(argMultimap.getValue(PREFIX_TUTORIAL).get());
+
+        return new ResetCommand(index, tutorial);
+    }
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -74,12 +74,24 @@ public class SampleDataUtil {
         return getTutorialMap(strings, attendance);
     }
 
+    /**
+     * Generates a {@code Map<Tutorial, AttendanceStatus} based on the given strings by calling the overloaded method
+     * and defaulting attendance to not taken place.
+     * @param strings Array of tutorial indexes.
+     * @return A map with containing each tutorial mapped to its attendance.
+     */
     public static Map<Tutorial, AttendanceStatus> getTutorialMap(String ... strings) {
         AttendanceStatus[] attendance = new AttendanceStatus[strings.length];
         Arrays.fill(attendance, AttendanceStatus.NOT_TAKEN_PLACE);
         return getTutorialMap(strings, attendance);
     }
 
+    /**
+     * Generates a {@code Map<Tutorial, AttendanceStatus} based on the given arrays.
+     * @param strings Array of tutorial indexes.
+     * @param attendance Array of attendance corresponding to each tutorial.
+     * @return A map with containing each tutorial mapped to its attendance.
+     */
     public static Map<Tutorial, AttendanceStatus> getTutorialMap(String[] strings, AttendanceStatus[] attendance) {
         Map<Tutorial, AttendanceStatus> tutorialMap = new LinkedHashMap<>();
         for (int i = 0; i < strings.length; i++) {

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -77,6 +77,7 @@ public class SampleDataUtil {
     /**
      * Generates a {@code Map<Tutorial, AttendanceStatus} based on the given strings by calling the overloaded method
      * and defaulting attendance to not taken place.
+     *
      * @param strings Array of tutorial indexes.
      * @return A map with containing each tutorial mapped to its attendance.
      */
@@ -88,6 +89,7 @@ public class SampleDataUtil {
 
     /**
      * Generates a {@code Map<Tutorial, AttendanceStatus} based on the given arrays.
+     *
      * @param strings Array of tutorial indexes.
      * @param attendance Array of attendance corresponding to each tutorial.
      * @return A map with containing each tutorial mapped to its attendance.

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -81,8 +81,6 @@ public class SampleDataUtil {
     }
 
     public static Map<Tutorial, AttendanceStatus> getTutorialMap(String[] strings, AttendanceStatus[] attendance) {
-        System.out.println(Arrays.toString(strings));
-        System.out.println(Arrays.toString(attendance));
         Map<Tutorial, AttendanceStatus> tutorialMap = new LinkedHashMap<>();
         for (int i = 0; i < strings.length; i++) {
             tutorialMap.put(new Tutorial(strings[i]), attendance[i]);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -39,6 +39,7 @@ public class CommandTestUtil {
     public static final String VALID_TAG_FRIEND = "friend";
     public static final String VALID_TUTORIAL_ONE = "1";
     public static final String VALID_TUTORIAL_TWO = "2";
+    public static final String INVALID_PERSON_INDEX = "-1";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/logic/commands/ResetCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ResetCommandTest.java
@@ -3,6 +3,9 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PERSON_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TUTORIAL_ONE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TUTORIAL_TWO;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -30,14 +33,13 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Tutorial;
 
 public class ResetCommandTest {
-    private static final String TUTORIAL_TO_TEST = "1";
-    private Model markedModel = new ModelManager(getMarkedAddressBook(TUTORIAL_TO_TEST), new UserPrefs());
+    private Model markedModel = new ModelManager(getMarkedAddressBook(VALID_TUTORIAL_ONE), new UserPrefs());
 
     @Test
     public void constructor_invalidIndex_throwsParseException() {
         assertThrows(ParseException.class, () ->
-                new ResetCommand(ParserUtil.parseIndex("-1"),
-                        new Tutorial(TUTORIAL_TO_TEST)).execute(markedModel));
+                new ResetCommand(ParserUtil.parseIndex(INVALID_PERSON_INDEX),
+                        new Tutorial(VALID_TUTORIAL_ONE)).execute(markedModel));
     }
 
     /**
@@ -45,14 +47,14 @@ public class ResetCommandTest {
      */
     @Test
     public void execute_tutorialAlreadyReset_failure() {
-        ResetCommand resetCommand = new ResetCommand(INDEX_FIRST_PERSON, new Tutorial(TUTORIAL_TO_TEST));
+        ResetCommand resetCommand = new ResetCommand(INDEX_FIRST_PERSON, new Tutorial(VALID_TUTORIAL_ONE));
         try {
             resetCommand.execute(markedModel);
 
             // Second execution should fail
             assertCommandFailure(resetCommand, markedModel, String.format(Messages.MESSAGE_RESET_UNNECESSARY,
                     Messages.format(markedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased())),
-                    new Tutorial("1").tutorial));
+                    new Tutorial(VALID_TUTORIAL_ONE).tutorial));
         } catch (CommandException e) {
             // Should not get here
             throw new RuntimeException();
@@ -61,7 +63,7 @@ public class ResetCommandTest {
 
     @Test
     public void execute_success() {
-        Tutorial tutorialToBeAdded = new Tutorial(TUTORIAL_TO_TEST);
+        Tutorial tutorialToBeAdded = new Tutorial(VALID_TUTORIAL_ONE);
 
         Person personToEdit = markedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         ResetCommand resetCommand = new ResetCommand(INDEX_FIRST_PERSON, tutorialToBeAdded);
@@ -91,7 +93,7 @@ public class ResetCommandTest {
         Model expectedModel = new ModelManager(new AddressBook(markedModel.getAddressBook()), new UserPrefs());
         String expectedMessage = String.format(Messages.MESSAGE_RESET_SUCCESS, Messages.format(editedPerson),
                 tutorialToBeAdded.tutorial);
-        Model typicalModel = new ModelManager(getMarkedAddressBook(TUTORIAL_TO_TEST), new UserPrefs());
+        Model typicalModel = new ModelManager(getMarkedAddressBook(VALID_TUTORIAL_ONE), new UserPrefs());
         assertCommandSuccess(resetCommand, typicalModel, expectedMessage, expectedModel);
     }
 
@@ -100,9 +102,9 @@ public class ResetCommandTest {
      */
     @Test
     public void execute_shouldResetAll_success() {
-        Tutorial tutorialToBeAdded = new Tutorial(TUTORIAL_TO_TEST);
+        Tutorial tutorialToBeReset = new Tutorial(VALID_TUTORIAL_ONE);
 
-        ResetCommand resetCommand = new ResetCommand(INDEX_ALL, tutorialToBeAdded);
+        ResetCommand resetCommand = new ResetCommand(INDEX_ALL, tutorialToBeReset);
 
         try {
             resetCommand.execute(markedModel);
@@ -113,7 +115,7 @@ public class ResetCommandTest {
         // Ensure all are edited and marked as reset
         for (Person person : markedModel.getFilteredPersonList()) {
             Map<Tutorial, AttendanceStatus> newTutorials = new LinkedHashMap<>(person.getTutorials());
-            newTutorials.put(tutorialToBeAdded, AttendanceStatus.NOT_TAKEN_PLACE);
+            newTutorials.put(tutorialToBeReset, AttendanceStatus.NOT_TAKEN_PLACE);
             Person expectedEditedPerson = new Person(
                     person.getName(),
                     person.getStudentId(),
@@ -131,14 +133,14 @@ public class ResetCommandTest {
         String expectedMessage = String.join("\n",
                 markedModel.getFilteredPersonList().stream()
                         .map(personToEdit -> String.format(Messages.MESSAGE_RESET_SUCCESS,
-                                Messages.format(personToEdit), tutorialToBeAdded.tutorial)).toArray(String[]::new));
-        Model typicalModel = new ModelManager(getMarkedAddressBook(TUTORIAL_TO_TEST), new UserPrefs());
+                                Messages.format(personToEdit), tutorialToBeReset.tutorial)).toArray(String[]::new));
+        Model typicalModel = new ModelManager(getMarkedAddressBook(VALID_TUTORIAL_ONE), new UserPrefs());
         assertCommandSuccess(resetCommand, typicalModel, expectedMessage, expectedModel);
     }
 
     @Test
     public void equals() {
-        Tutorial tutorial = new Tutorial(TUTORIAL_TO_TEST);
+        Tutorial tutorial = new Tutorial(VALID_TUTORIAL_ONE);
         ResetCommand resetCommand = new ResetCommand(INDEX_FIRST_PERSON, tutorial);
 
         // same object -> returns true
@@ -151,7 +153,7 @@ public class ResetCommandTest {
         assertFalse(resetCommand.equals(1));
 
         // same values -> return true
-        Tutorial duplicateTutorial = new Tutorial(TUTORIAL_TO_TEST);
+        Tutorial duplicateTutorial = new Tutorial(VALID_TUTORIAL_ONE);
         ResetCommand duplicateResetCommand = new ResetCommand(INDEX_FIRST_PERSON, duplicateTutorial);
         assertTrue(resetCommand.equals(duplicateResetCommand));
 
@@ -160,7 +162,7 @@ public class ResetCommandTest {
         assertFalse(resetCommand.equals(otherIndexResetCommand));
 
         // different tutorial -> return false
-        Tutorial otherTutorial = new Tutorial("2");
+        Tutorial otherTutorial = new Tutorial(VALID_TUTORIAL_TWO);
         ResetCommand otherTutResetCommand = new ResetCommand(INDEX_FIRST_PERSON, otherTutorial);
         assertFalse(resetCommand.equals(otherTutResetCommand));
     }

--- a/src/test/java/seedu/address/logic/commands/ResetCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ResetCommandTest.java
@@ -1,0 +1,167 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_ALL;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getMarkedAddressBook;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.AttendanceStatus;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Tutorial;
+
+public class ResetCommandTest {
+    private static final String TUTORIAL_TO_TEST = "1";
+    private Model markedModel = new ModelManager(getMarkedAddressBook(TUTORIAL_TO_TEST), new UserPrefs());
+
+    @Test
+    public void constructor_invalidIndex_throwsParseException() {
+        assertThrows(ParseException.class, () ->
+                new ResetCommand(ParserUtil.parseIndex("-1"),
+                        new Tutorial(TUTORIAL_TO_TEST)).execute(markedModel));
+    }
+
+    /**
+     * Reset a person's attendance which is already not taken place.
+     */
+    @Test
+    public void execute_tutorialAlreadyReset_failure() {
+        ResetCommand resetCommand = new ResetCommand(INDEX_FIRST_PERSON, new Tutorial(TUTORIAL_TO_TEST));
+        try {
+            resetCommand.execute(markedModel);
+
+            // Second execution should fail
+            assertCommandFailure(resetCommand, markedModel, String.format(Messages.MESSAGE_RESET_UNNECESSARY,
+                    Messages.format(markedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased())),
+                    new Tutorial("1").tutorial));
+        } catch (CommandException e) {
+            // Should not get here
+            throw new RuntimeException();
+        }
+    }
+
+    @Test
+    public void execute_success() {
+        Tutorial tutorialToBeAdded = new Tutorial(TUTORIAL_TO_TEST);
+
+        Person personToEdit = markedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        ResetCommand resetCommand = new ResetCommand(INDEX_FIRST_PERSON, tutorialToBeAdded);
+
+        try {
+            resetCommand.execute(markedModel);
+        } catch (CommandException e) {
+            throw new RuntimeException(e);
+        }
+
+        Person editedPerson = markedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        // Check person is edited
+        Map<Tutorial, AttendanceStatus> newTutorials = new HashMap<>(personToEdit.getTutorials());
+        newTutorials.put(tutorialToBeAdded, AttendanceStatus.NOT_TAKEN_PLACE);
+        Person expectedEditedPerson = new Person(
+                personToEdit.getName(),
+                personToEdit.getStudentId(),
+                personToEdit.getPhone(),
+                personToEdit.getEmail(),
+                personToEdit.getTags(),
+                newTutorials
+        );
+        assertEquals(expectedEditedPerson, editedPerson);
+
+        // Check model is updated with new person attribute
+        Model expectedModel = new ModelManager(new AddressBook(markedModel.getAddressBook()), new UserPrefs());
+        String expectedMessage = String.format(Messages.MESSAGE_RESET_SUCCESS, Messages.format(editedPerson),
+                tutorialToBeAdded.tutorial);
+        Model typicalModel = new ModelManager(getMarkedAddressBook(TUTORIAL_TO_TEST), new UserPrefs());
+        assertCommandSuccess(resetCommand, typicalModel, expectedMessage, expectedModel);
+    }
+
+    /**
+     * Reset all persons in the list.
+     */
+    @Test
+    public void execute_shouldResetAll_success() {
+        Tutorial tutorialToBeAdded = new Tutorial(TUTORIAL_TO_TEST);
+
+        ResetCommand resetCommand = new ResetCommand(INDEX_ALL, tutorialToBeAdded);
+
+        try {
+            resetCommand.execute(markedModel);
+        } catch (CommandException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Ensure all are edited and marked as reset
+        for (Person person : markedModel.getFilteredPersonList()) {
+            Map<Tutorial, AttendanceStatus> newTutorials = new LinkedHashMap<>(person.getTutorials());
+            newTutorials.put(tutorialToBeAdded, AttendanceStatus.NOT_TAKEN_PLACE);
+            Person expectedEditedPerson = new Person(
+                    person.getName(),
+                    person.getStudentId(),
+                    person.getPhone(),
+                    person.getEmail(),
+                    person.getTags(),
+                    newTutorials
+            );
+
+            assertEquals(expectedEditedPerson, person);
+        }
+
+        // Check model is updated with new person attribute
+        Model expectedModel = new ModelManager(new AddressBook(markedModel.getAddressBook()), new UserPrefs());
+        String expectedMessage = String.join("\n",
+                markedModel.getFilteredPersonList().stream()
+                        .map(personToEdit -> String.format(Messages.MESSAGE_RESET_SUCCESS,
+                                Messages.format(personToEdit), tutorialToBeAdded.tutorial)).toArray(String[]::new));
+        Model typicalModel = new ModelManager(getMarkedAddressBook(TUTORIAL_TO_TEST), new UserPrefs());
+        assertCommandSuccess(resetCommand, typicalModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        Tutorial tutorial = new Tutorial(TUTORIAL_TO_TEST);
+        ResetCommand resetCommand = new ResetCommand(INDEX_FIRST_PERSON, tutorial);
+
+        // same object -> returns true
+        assertTrue(resetCommand.equals(resetCommand));
+
+        // null -> returns false
+        assertFalse(resetCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(resetCommand.equals(1));
+
+        // same values -> return true
+        Tutorial duplicateTutorial = new Tutorial(TUTORIAL_TO_TEST);
+        ResetCommand duplicateResetCommand = new ResetCommand(INDEX_FIRST_PERSON, duplicateTutorial);
+        assertTrue(resetCommand.equals(duplicateResetCommand));
+
+        // different index -> return false
+        ResetCommand otherIndexResetCommand = new ResetCommand(INDEX_SECOND_PERSON, tutorial);
+        assertFalse(resetCommand.equals(otherIndexResetCommand));
+
+        // different tutorial -> return false
+        Tutorial otherTutorial = new Tutorial("2");
+        ResetCommand otherTutResetCommand = new ResetCommand(INDEX_FIRST_PERSON, otherTutorial);
+        assertFalse(resetCommand.equals(otherTutResetCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ResetCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResetCommandParserTest.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.TUTORIAL_DESC_ONE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TUTORIAL_ONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_ALL;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ResetCommand;
+import seedu.address.model.person.Tutorial;
+
+public class ResetCommandParserTest {
+    private ResetCommandParser parser = new ResetCommandParser();
+
+    @Test
+    public void parse_validTutorial_success() {
+        // whitespace only preamble
+        assertParseSuccess(parser, INDEX_FIRST_PERSON.getOneBased() + TUTORIAL_DESC_ONE,
+                new ResetCommand(INDEX_FIRST_PERSON, new Tutorial(VALID_TUTORIAL_ONE)));
+    }
+
+    @Test
+    public void parse_wildcard_success() {
+        assertParseSuccess(parser, ParserUtil.WILDCARD + TUTORIAL_DESC_ONE,
+                new ResetCommand(INDEX_ALL, new Tutorial(VALID_TUTORIAL_ONE)));
+    }
+
+    @Test
+    public void parse_missingIndex_failure() {
+        assertParseFailure(parser, TUTORIAL_DESC_ONE, ParserUtil.MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void parse_missingPrefix_failure() {
+        assertParseFailure(parser, String.valueOf(INDEX_FIRST_PERSON.getOneBased()),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ResetCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_missingTutorial_failure() {
+        assertParseFailure(parser, INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_TUTORIAL,
+                Tutorial.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_emptyInput_failure() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                ResetCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_whitespaceInput_failure() {
+        assertParseFailure(parser, "   ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                ResetCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -104,6 +104,14 @@ public class PersonBuilder {
     }
 
     /**
+     * Amends the stated tutorial and set it to the {@code Person} that we are building.
+     */
+    public PersonBuilder withAmendedTutorial(String tutorialIndex, AttendanceStatus attendanceStatus) {
+        this.tutorials.put(new Tutorial(tutorialIndex), attendanceStatus);
+        return this;
+    }
+
+    /**
      * Sets the {@code Phone} of the {@code Person} that we are building.
      */
     public PersonBuilder withPhone(String phone) {

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 
 import seedu.address.model.AddressBook;
+import seedu.address.model.person.AttendanceStatus;
 import seedu.address.model.person.Person;
 
 /**
@@ -75,6 +76,17 @@ public class TypicalPersons {
     }
 
     /**
+     * Returns an {@code AddressBook} with all the typical persons with a specific tutorial marked as present.
+     */
+    public static AddressBook getMarkedAddressBook(String tutorialIndex) {
+        AddressBook ab = new AddressBook();
+        for (Person person : getMarkedPersons(tutorialIndex)) {
+            ab.addPerson(person);
+        }
+        return ab;
+    }
+
+    /**
      * Returns an {@code AddressBook} with all the typical persons in random order.
      */
     public static AddressBook getShuffledTypicalAddressBook() {
@@ -87,6 +99,16 @@ public class TypicalPersons {
 
     public static List<Person> getTypicalPersons() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+    }
+
+    public static List<Person> getMarkedPersons(String tutorialIndex) {
+        List<Person> markedPersons = new ArrayList<>();
+        for (Person p : getTypicalPersons()) {
+            markedPersons.add(new PersonBuilder(p)
+                    .withAmendedTutorial(tutorialIndex, AttendanceStatus.PRESENT)
+                    .build());
+        }
+        return markedPersons;
     }
 
     public static List<Person> getShuffledTypicalPersons() {


### PR DESCRIPTION
Tutors might need to reset tutorials to the state of not taken place in case of typos. Added a ResetCommand to do so.

Resolves #95. 